### PR TITLE
fix circular reference error with newer ruby

### DIFF
--- a/lib/kingkong/ping.rb
+++ b/lib/kingkong/ping.rb
@@ -119,7 +119,7 @@ module KingKong
 
   private
     # Spits out a key and run for a result
-    def key(count=count)
+    def key(count=count())
       "#{count}:#{run}"
     end
   end


### PR DESCRIPTION
@bradgessler guess we still use this in pinger and it fails now with ruby 2.7. This is a quick fix for the circular reference error.

Tested manually in pinger and it removes the error.